### PR TITLE
External links should be internal if Github

### DIFF
--- a/ResoniteFixContactIcons.cs
+++ b/ResoniteFixContactIcons.cs
@@ -18,7 +18,7 @@ namespace ResoniteFixContactIcons
         public override string Name => "ResoniteFixContactIcons";
         public override string Author => "NepuShiro";
         public override string Version => VERSION_CONSTANT;
-        public override string Link => "https://git.nepu.men/NepuShiro/ResoniteFixContactIcons/";
+        public override string Link => "https://github.com/NepuShiro/ResoniteFixContactIcons/";
 
         public override void OnEngineInit()
         {


### PR DESCRIPTION
Changed external link to Github since the mod is hosted on Github. This also fixes ResoniteModUpdater CLI being unable to fetch the mod's DLL.